### PR TITLE
Specify modelica libraries path in LSP initialization options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 modelica-language-server*.vsix
 node_modules/
 out/
+client/testFixture/.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -22,6 +22,39 @@ features:
 
     ![Goto Declaration](images/goto_declaration_demo.png)
 
+## Configuration
+
+### Loading external Modelica libraries
+
+To make the language server aware of libraries outside your workspace (such as
+the Modelica Standard Library), add their root directories to
+`modelica.libraries` in your VS Code settings.
+
+**Workspace settings** (`.vscode/settings.json`):
+
+```json
+{
+  "modelica.libraries": [
+    "/path/to/Modelica 4.0.0+maint.om"
+  ]
+}
+```
+
+**User settings** (via *File → Preferences → Settings*, search for
+`modelica.libraries`): click *Add Item* and enter the path to each library
+root directory — the folder that contains a `package.mo` file.
+
+Typical paths:
+
+| Platform | Default OpenModelica library location    |
+|----------|------------------------------------------|
+| Linux    | `~/.openmodelica/libraries/`             |
+| Windows  | `%APPDATA%\OpenModelica\libraries\`      |
+| macOS    | `~/.openmodelica/libraries/`             |
+
+The server loads all configured libraries at startup. Changes take effect after
+reloading the VS Code window (**Developer: Reload Window**).
+
 ## Installation
 
 ### Via Marketplace

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -101,6 +101,9 @@ export function activate(context: ExtensionContext) {
       // Notify the server about file changes to '.clientrc files contained in the workspace
       fileEvents: workspace.createFileSystemWatcher('**/.clientrc'),
     },
+    initializationOptions: {
+      libraries: workspace.getConfiguration('modelica').get<string[]>('libraries', []),
+    },
   };
 
   // Create the language client and start the client.

--- a/client/src/test/mslLibrary.test.ts
+++ b/client/src/test/mslLibrary.test.ts
@@ -1,0 +1,69 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+import { getDocUri, activate } from './helper';
+
+suite('MSL Library Support', () => {
+  test('go-to-declaration resolves MSL type into MSL directory', async () => {
+    const libraries: string[] =
+      vscode.workspace.getConfiguration('modelica').get('libraries') ?? [];
+    if (libraries.length === 0) {
+      console.log('Skipping MSL test: no modelica.libraries configured');
+      return;
+    }
+
+    const docUri = getDocUri('UseMSL.mo');
+    await activate(docUri);
+
+    // Line 2: "    Modelica.Units.SI.Voltage v;" — cursor on "Modelica" at column 4
+    const position = new vscode.Position(2, 4);
+    const actualLocations = await vscode.commands.executeCommand<vscode.LocationLink[]>(
+      'vscode.executeDeclarationProvider',
+      docUri,
+      position,
+    );
+
+    assert.ok(actualLocations.length > 0, 'Expected at least one declaration location');
+
+    const targetPath = actualLocations[0].targetUri.fsPath;
+    const mslDir = libraries[0];
+    assert.ok(
+      targetPath.startsWith(mslDir),
+      `Expected declaration to resolve into MSL directory '${mslDir}', got '${targetPath}'`,
+    );
+  });
+});

--- a/client/src/test/runTest.ts
+++ b/client/src/test/runTest.ts
@@ -34,8 +34,20 @@
  */
 
 import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
 
 import { runTests } from '@vscode/test-electron';
+
+const MSL_CANDIDATES = [
+  path.join(os.homedir(), '.openmodelica', 'libraries', 'Modelica 4.0.0+maint.om'),
+  path.join(os.homedir(), '.openmodelica', 'libraries', 'Modelica 4.1.0+maint.om'),
+  '/usr/lib/omlibrary/Modelica 4.0.0+maint.om',
+];
+
+function detectMsl(): string | undefined {
+  return MSL_CANDIDATES.find((p) => fs.existsSync(path.join(p, 'package.mo')));
+}
 
 async function main() {
   try {
@@ -47,8 +59,28 @@ async function main() {
     // Passed to --extensionTestsPath
     const extensionTestsPath = path.resolve(__dirname, './index');
 
+    // Use the testFixture folder as VS Code workspace so .vscode/settings.json is picked up
+    const testFixturePath = path.resolve(__dirname, '../../testFixture');
+
+    // Write workspace settings with MSL path if found on this machine
+    const mslPath = detectMsl();
+    const vscodeDir = path.join(testFixturePath, '.vscode');
+    fs.mkdirSync(vscodeDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(vscodeDir, 'settings.json'),
+      JSON.stringify(
+        { 'modelica.libraries': mslPath ? [mslPath] : [] },
+        null,
+        2,
+      ),
+    );
+
     // Download VS Code, unzip it and run the integration test
-    await runTests({ extensionDevelopmentPath, extensionTestsPath });
+    await runTests({
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [testFixturePath],
+    });
   } catch (err) {
     console.error('Failed to run tests');
     process.exit(1);

--- a/client/testFixture/UseMSL.mo
+++ b/client/testFixture/UseMSL.mo
@@ -1,0 +1,5 @@
+package UseMSL "Minimal package using Modelica Standard Library"
+  model M
+    Modelica.Units.SI.Voltage v;
+  end M;
+end UseMSL;

--- a/package-lock.json
+++ b/package-lock.json
@@ -641,6 +641,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
       "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -691,6 +692,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -852,6 +854,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1274,6 +1277,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2575,6 +2579,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
       "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,20 @@
   ],
   "main": "./out/client",
   "contributes": {
+    "configuration": {
+      "type": "object",
+      "title": "Modelica Language Server",
+      "properties": {
+        "modelica.libraries": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "List of paths to Modelica library root directories to load on startup."
+        }
+      }
+    },
     "languages": [
       {
         "id": "modelica",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -43,6 +43,7 @@ import * as LSP from 'vscode-languageserver/node';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import url from 'node:url';
 import fs from 'node:fs/promises';
+import path from 'node:path';
 
 import { initializeParser } from './parser';
 import Analyzer from './analyzer';
@@ -69,7 +70,7 @@ export class ModelicaServer {
 
   public static async initialize(
     connection: LSP.Connection,
-    { capabilities, workspaceFolders }: LSP.InitializeParams,
+    { capabilities, workspaceFolders, initializationOptions }: LSP.InitializeParams,
   ): Promise<ModelicaServer> {
     // Initialize logger
     setLoggerOptions({
@@ -85,7 +86,27 @@ export class ModelicaServer {
         await analyzer.loadLibrary(workspace.uri, true);
       }
     }
-    // TODO: add libraries as well
+
+    const configuredLibraries = [
+      ...(Array.isArray(
+        (initializationOptions as { modelicaPath?: unknown } | undefined)?.modelicaPath,
+      )
+        ? (initializationOptions as { modelicaPath: unknown[] }).modelicaPath.filter(
+            (value): value is string => typeof value === 'string' && value.length > 0,
+          )
+        : []),
+      ...(Array.isArray((initializationOptions as { libraries?: unknown } | undefined)?.libraries)
+        ? (initializationOptions as { libraries: unknown[] }).libraries.filter(
+            (value): value is string => typeof value === 'string' && value.length > 0,
+          )
+        : []),
+    ];
+
+    for (const libraryPath of configuredLibraries) {
+      const libraryUri = url.pathToFileURL(path.resolve(libraryPath)).toString();
+      logger.debug(`Loading configured library '${libraryPath}'`);
+      await analyzer.loadLibrary(libraryUri, false);
+    }
 
     logger.debug('Initialized');
     return new ModelicaServer(analyzer, capabilities, connection);


### PR DESCRIPTION
This PR modifies language server to accept library paths from initialization options via both `modelicaPath` and `libraries` key-values. It filters the configured values to non-empty strings, resolve them to file URIs, and load each library during server initialization so configured Modelica paths are available to the analyzer.

This lets clients provide library paths up front so the analyzer has access to configured Modelica libraries immediately after startup.