### PR TITLE
Fix resolving symbols standalone files

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/client/src/test/gotoDeclaration.test.ts
+++ b/client/src/test/gotoDeclaration.test.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/client/src/test/helper.ts
+++ b/client/src/test/helper.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/client/src/test/index.ts
+++ b/client/src/test/index.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/client/src/test/mslLibrary.test.ts
+++ b/client/src/test/mslLibrary.test.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/client/src/test/runTest.ts
+++ b/client/src/test/runTest.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/client/src/test/symbolinformation.test.ts
+++ b/client/src/test/symbolinformation.test.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/server/src/analysis/reference.ts
+++ b/server/src/analysis/reference.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/server/src/analysis/resolveReference.ts
+++ b/server/src/analysis/resolveReference.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/server/src/analysis/resolveReference.ts
+++ b/server/src/analysis/resolveReference.ts
@@ -441,11 +441,39 @@ function resolveAbsoluteReference(
   logger.debug(`Resolving ${reference}`);
 
   logger.debug(project.libraries.map((x) => x.name + ' | ' + x.path).join('\n\t'));
-  const library = project.libraries.find((lib) => lib.name === reference.symbols[0]);
-  if (library == null) {
+
+  // Multiple libraries may share the same name (e.g. a standalone file and a
+  // directory package with the same top-level class). Try each of them until
+  // one resolves the full reference chain.
+  const libraries = project.libraries.filter((lib) => lib.name === reference.symbols[0]);
+  if (libraries.length === 0) {
     logger.debug(`Couldn't find library: ${reference.symbols[0]}`);
     return null;
   }
+
+  for (const library of libraries) {
+    const resolved = resolveReferenceInLibrary(library, reference);
+    if (resolved != null) {
+      logger.debug(`Resolved symbol ${resolved}`);
+      return resolved;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Attempts to resolve an absolute reference chain within a single library.
+ *
+ * @param library the library to search
+ * @param reference an absolute reference
+ * @returns a resolved reference, or `null` if the chain could not be resolved
+ *     in this library
+ */
+function resolveReferenceInLibrary(
+  library: ModelicaLibrary,
+  reference: UnresolvedAbsoluteReference,
+): ResolvedReference | null {
 
   let alreadyResolved: ResolvedReference | null = null;
   for (let i = 0; i < reference.symbols.length; i++) {

--- a/server/src/analysis/test/resolveReference.test.ts
+++ b/server/src/analysis/test/resolveReference.test.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/server/src/analyzer.ts
+++ b/server/src/analyzer.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/server/src/analyzer.ts
+++ b/server/src/analyzer.ts
@@ -100,7 +100,7 @@ export default class Analyzer {
     // TODO: go deeper... something like `TreeSitterUtil.forEach` but for files
     //       would be good here
     for (const nestedRelative of await fs.readdir(libraryPath)) {
-      const nested = path.resolve(nestedRelative);
+      const nested = path.resolve(libraryPath, nestedRelative);
       if (!isLibrary(nested)) {
         continue;
       }
@@ -326,10 +326,6 @@ export default class Analyzer {
   /**
    * Locates the first node at the given text position that matches the given
    * `condition`, starting from the `rootNode`.
-   *
-   * Note: it is very important to have some kind of condition. If one tries to
-   * just accept the first node at that position, this function will always
-   * return the `rootNode` (or `undefined` if outside the node.)
    *
    * @param rootNode node to start searching from. parents/siblings of this node will be ignored
    * @param offset the offset of the symbol from the start of the document

--- a/server/src/parser.ts
+++ b/server/src/parser.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/server/src/project/document.ts
+++ b/server/src/project/document.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/server/src/project/index.ts
+++ b/server/src/project/index.ts
@@ -1,3 +1,38 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
 export { ModelicaDocument } from "./document";
 export { ModelicaLibrary } from "./library";
 export { ModelicaProject } from "./project";

--- a/server/src/project/library.ts
+++ b/server/src/project/library.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/server/src/project/library.ts
+++ b/server/src/project/library.ts
@@ -44,7 +44,7 @@ export class ModelicaLibrary {
   readonly #project: ModelicaProject;
   readonly #documents: Map<string, ModelicaDocument>;
   readonly #isWorkspace: boolean;
-  readonly #name: string;
+  #name: string;
   #path: string;
 
   public constructor(
@@ -108,6 +108,10 @@ export class ModelicaLibrary {
 
   public get name(): string {
     return this.#name;
+  }
+
+  public rename(newName: string): void {
+    this.#name = newName;
   }
 
   public get path(): string {

--- a/server/src/project/project.ts
+++ b/server/src/project/project.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/server/src/project/project.ts
+++ b/server/src/project/project.ts
@@ -40,6 +40,7 @@ import path from 'node:path';
 import { ModelicaLibrary } from './library';
 import { ModelicaDocument } from './document';
 import { logger } from '../util/logger';
+import * as TreeSitterUtil from '../util/tree-sitter';
 
 /** Options for {@link ModelicaProject.getDocument} */
 export interface GetDocumentOptions {
@@ -139,15 +140,19 @@ export class ModelicaProject {
 
     // If the document doesn't belong to a library, it could still be loaded
     // as a standalone document if it has an empty or non-existent within clause
-    const standaloneName = path.basename(documentPath).split('.')[0];
+    const fallbackName = path.basename(documentPath).split('.')[0];
     const standaloneLibrary = new ModelicaLibrary(
       this,
       path.dirname(documentPath),
       false,
-      standaloneName,
+      fallbackName,
     );
     const document = await ModelicaDocument.load(this, standaloneLibrary, documentPath);
     if (document.within.length === 0) {
+      // Use the declared class name as the library name so resolution can find it by class name.
+      const classNames = TreeSitterUtil.getDeclaredIdentifiers(document.tree.rootNode);
+      standaloneLibrary.rename(classNames[0] ?? fallbackName);
+      standaloneLibrary.documents.set(documentPath, document);
       this.addLibrary(standaloneLibrary);
       logger.debug(`Added document: ${documentPath}`);
       return document;

--- a/server/src/project/test/document.test.ts
+++ b/server/src/project/test/document.test.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/server/src/project/test/project.test.ts
+++ b/server/src/project/test/project.test.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/server/src/test/analyzer.test.ts
+++ b/server/src/test/analyzer.test.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/server/src/test/server.test.ts
+++ b/server/src/test/server.test.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/server/src/util/declarations.ts
+++ b/server/src/util/declarations.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/server/src/util/index.ts
+++ b/server/src/util/index.ts
@@ -1,6 +1,40 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
 import * as url from "node:url";
 import * as LSP from "vscode-languageserver";
-
 
 export const uriToPath = url.fileURLToPath;
 

--- a/server/src/util/logger.ts
+++ b/server/src/util/logger.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/server/src/util/test/declarations.test.ts
+++ b/server/src/util/test/declarations.test.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/server/src/util/test/util.test.ts
+++ b/server/src/util/test/util.test.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/server/src/util/tree-sitter.ts
+++ b/server/src/util/tree-sitter.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *


### PR DESCRIPTION
## Issue

Resolving symbols failed when the workspace contained a standalone file
whose class name differed from its filename, or multiple libraries
sharing the same top-level name.

## Changes

Fix reference resolution for standalone files and same-named libraries

- analyzer.ts: resolve nested library entries against `libraryPath`
  instead of the process CWD, so nested packages are discovered
  consistently.
- resolveReference.ts: iterate over all libraries matching the first
  symbol instead of only the first `find` match, so resolution doesn't
  give up when a same-named library lacks the symbol.
- project.ts: register standalone documents under their declared class
  name (not the filename) so they can be resolved by class name.
- library.ts: allow a library's name to be reassigned via `rename()`.
- Update all OSMC copyright claims