### PR TITLE
Unload libraries removed from configuration

### DIFF
--- a/server/src/analyzer.ts
+++ b/server/src/analyzer.ts
@@ -119,11 +119,34 @@ export default class Analyzer {
    * without restarting the server.
    *
    * @param uri uri to the library/workspace root
+   * @param options optional ownership filters for configuration-driven unloads
    * @returns the file-system paths of the libraries that were unloaded
    */
-  public unloadLibrary(uri: LSP.URI): string[] {
+  public unloadLibrary(
+    uri: LSP.URI,
+    options?: { preserveWorkspaces?: boolean; preservePaths?: ReadonlySet<string> },
+  ): string[] {
     const rootPath = path.resolve(url.fileURLToPath(uri));
-    return this.#project.removeLibrariesUnder(rootPath);
+    const isAtOrBelow = (parent: string, child: string): boolean => {
+      const relative = path.relative(parent, child);
+      return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+    };
+
+    return this.#project.removeLibrariesUnder(rootPath, (library) => {
+      if (options?.preserveWorkspaces && library.isWorkspace) {
+        return false;
+      }
+
+      // A library loaded through modelicaPath must remain available even if
+      // the same path is later removed from modelica.libraries.
+      for (const preservedPath of options?.preservePaths ?? []) {
+        if (isAtOrBelow(path.resolve(preservedPath), path.resolve(library.path))) {
+          return false;
+        }
+      }
+
+      return true;
+    });
   }
 
   /**

--- a/server/src/project/project.ts
+++ b/server/src/project/project.ts
@@ -72,13 +72,18 @@ export class ModelicaProject {
   /**
    * Removes every library whose root is at or below `rootPath` (e.g. all
    * libraries discovered under a removed workspace folder), dropping their
-   * loaded documents. Libraries and standalone documents outside `rootPath`
-   * are left untouched.
+   * loaded documents. The optional predicate can retain libraries that are
+   * still owned by another source. Libraries and standalone documents outside
+   * `rootPath` are left untouched.
    *
    * @param rootPath absolute path of the removed workspace/library root
+   * @param shouldRemove predicate deciding which matching libraries to remove
    * @returns the root paths of the libraries that were removed
    */
-  public removeLibrariesUnder(rootPath: string): string[] {
+  public removeLibrariesUnder(
+    rootPath: string,
+    shouldRemove: (library: ModelicaLibrary) => boolean = () => true,
+  ): string[] {
     const removed: string[] = [];
     for (let i = this.#libraries.length - 1; i >= 0; i--) {
       const libraryPath = this.#libraries[i].path;
@@ -86,7 +91,7 @@ export class ModelicaProject {
       const isAtOrBelow =
         libraryPath === rootPath ||
         (relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative));
-      if (isAtOrBelow) {
+      if (isAtOrBelow && shouldRemove(this.#libraries[i])) {
         removed.push(libraryPath);
         this.#libraries.splice(i, 1);
       }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -60,6 +60,10 @@ export class ModelicaServer {
   // analyzer, so a later notification about the same folder is a no-op
   // instead of loading it (and all its documents) a second time.
   #loadedLibraryPaths: Set<string> = new Set();
+  // Absolute paths from the latest modelica.libraries configuration. Keep
+  // these separate from loaded paths so a shrunken configuration can unload
+  // roots that disappeared from it.
+  #configuredLibraryPaths: Set<string> = new Set();
 
   private constructor(analyzer: Analyzer, connection: LSP.Connection) {
     this.#analyzer = analyzer;
@@ -87,24 +91,25 @@ export class ModelicaServer {
       }
     }
 
-    const configuredLibraries = [
-      ...(Array.isArray(
-        (initializationOptions as { modelicaPath?: unknown } | undefined)?.modelicaPath,
-      )
-        ? (initializationOptions as { modelicaPath: unknown[] }).modelicaPath.filter(
-            (value): value is string => typeof value === 'string' && value.length > 0,
-          )
-        : []),
-      ...(Array.isArray((initializationOptions as { libraries?: unknown } | undefined)?.libraries)
-        ? (initializationOptions as { libraries: unknown[] }).libraries.filter(
-            (value): value is string => typeof value === 'string' && value.length > 0,
-          )
-        : []),
-    ];
+    const modelicaPath = Array.isArray(
+      (initializationOptions as { modelicaPath?: unknown } | undefined)?.modelicaPath,
+    )
+      ? (initializationOptions as { modelicaPath: unknown[] }).modelicaPath.filter(
+          (value): value is string => typeof value === 'string' && value.length > 0,
+        )
+      : [];
+    const configuredLibraries = Array.isArray(
+      (initializationOptions as { libraries?: unknown } | undefined)?.libraries,
+    )
+      ? (initializationOptions as { libraries: unknown[] }).libraries.filter(
+          (value): value is string => typeof value === 'string' && value.length > 0,
+        )
+      : [];
 
-    for (const libraryPath of configuredLibraries) {
+    for (const libraryPath of [...modelicaPath, ...configuredLibraries]) {
       await server.#loadConfiguredLibrary(libraryPath);
     }
+    server.#configuredLibraryPaths = new Set(configuredLibraries.map((value) => path.resolve(value)));
 
     logger.debug('Initialized');
     return server;
@@ -347,21 +352,30 @@ export class ModelicaServer {
   }
 
   /**
-   * Loads libraries added to `modelica.libraries` after startup, so a
+   * Synchronizes libraries with `modelica.libraries` after startup, so a
    * client can push an updated library list without restarting the server.
    */
   private async onDidChangeConfiguration(params: LSP.DidChangeConfigurationParams): Promise<void> {
     logger.debug('onDidChangeConfiguration');
     const settings = params.settings as { modelica?: { libraries?: unknown } } | undefined;
-    const libraries = Array.isArray(settings?.modelica?.libraries)
-      ? settings.modelica.libraries.filter(
-          (value): value is string => typeof value === 'string' && value.length > 0,
-        )
-      : [];
+    if (!Array.isArray(settings?.modelica?.libraries)) {
+      return;
+    }
+    const libraries = settings.modelica.libraries.filter(
+      (value): value is string => typeof value === 'string' && value.length > 0,
+    );
+    const configuredLibraryPaths = new Set(libraries.map((value) => path.resolve(value)));
+
+    for (const previousPath of this.#configuredLibraryPaths) {
+      if (!configuredLibraryPaths.has(previousPath)) {
+        this.#unloadLibrary(url.pathToFileURL(previousPath).toString());
+      }
+    }
 
     for (const libraryPath of libraries) {
       await this.#loadConfiguredLibrary(libraryPath);
     }
+    this.#configuredLibraryPaths = configuredLibraryPaths;
   }
 
   // TODO: We currently treat goto declaration and goto definition the same,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -64,6 +64,9 @@ export class ModelicaServer {
   // these separate from loaded paths so a shrunken configuration can unload
   // roots that disappeared from it.
   #configuredLibraryPaths: Set<string> = new Set();
+  // modelicaPath libraries are startup-only, but may overlap with a later
+  // modelica.libraries update and must not be unloaded by that update.
+  #modelicaPathLibraryPaths: Set<string> = new Set();
 
   private constructor(analyzer: Analyzer, connection: LSP.Connection) {
     this.#analyzer = analyzer;
@@ -109,6 +112,7 @@ export class ModelicaServer {
     for (const libraryPath of [...modelicaPath, ...configuredLibraries]) {
       await server.#loadConfiguredLibrary(libraryPath);
     }
+    server.#modelicaPathLibraryPaths = new Set(modelicaPath.map((value) => path.resolve(value)));
     server.#configuredLibraryPaths = new Set(configuredLibraries.map((value) => path.resolve(value)));
 
     logger.debug('Initialized');
@@ -323,7 +327,10 @@ export class ModelicaServer {
    * Unloads every library under a removed workspace folder and forgets its
    * path so the same folder can be added again later.
    */
-  #unloadLibrary(uri: LSP.URI): void {
+  #unloadLibrary(
+    uri: LSP.URI,
+    options?: { preserveWorkspaces?: boolean; preservePaths?: ReadonlySet<string> },
+  ): void {
     let normalizedRoot: string;
     try {
       normalizedRoot = path.resolve(url.fileURLToPath(uri));
@@ -335,8 +342,10 @@ export class ModelicaServer {
       return;
     }
 
-    const removedPaths = this.#analyzer.unloadLibrary(uri);
-    this.#loadedLibraryPaths.delete(normalizedRoot);
+    const removedPaths = this.#analyzer.unloadLibrary(uri, options);
+    if (!options?.preserveWorkspaces) {
+      this.#loadedLibraryPaths.delete(normalizedRoot);
+    }
     for (const removed of removedPaths) {
       this.#loadedLibraryPaths.delete(path.resolve(removed));
     }
@@ -368,7 +377,10 @@ export class ModelicaServer {
 
     for (const previousPath of this.#configuredLibraryPaths) {
       if (!configuredLibraryPaths.has(previousPath)) {
-        this.#unloadLibrary(url.pathToFileURL(previousPath).toString());
+        this.#unloadLibrary(url.pathToFileURL(previousPath).toString(), {
+          preserveWorkspaces: true,
+          preservePaths: this.#modelicaPathLibraryPaths,
+        });
       }
     }
 

--- a/server/src/test/runtimeLibraryLoad.test.ts
+++ b/server/src/test/runtimeLibraryLoad.test.ts
@@ -399,6 +399,42 @@ describe('runtime library loading', () => {
     }
   });
 
+  it('stops resolving a library removed via didChangeConfiguration', async function () {
+    this.timeout(20_000);
+
+    const client = new LspTestClient();
+    try {
+      const nUri = fileUri(FILE_N);
+      const nText = fs.readFileSync(FILE_N, 'utf8');
+      const position = positionOf(nText, 'extends RuntimeLoadLibA.M', 'RuntimeLoadLibA.M');
+
+      await initializeWithLibB(client);
+      client.notify('textDocument/didOpen', {
+        textDocument: { uri: nUri, languageId: 'modelica', version: 1, text: nText },
+      });
+      client.notify('workspace/didChangeConfiguration', {
+        settings: { modelica: { libraries: [LIB_A] } },
+      });
+
+      const loaded = await waitForDefinition(client, nUri, position, 5_000);
+      assert.ok(Array.isArray(loaded) && loaded.length > 0, 'libA should resolve after config add');
+
+      client.notify('workspace/didChangeConfiguration', {
+        settings: { modelica: { libraries: [] } },
+      });
+
+      assert.ok(await client.waitForLog('Unloaded 1 library', 5_000), 'libA should be unloaded');
+      const after = await client.request('textDocument/definition', {
+        textDocument: { uri: nUri },
+        position,
+      });
+      assert.deepEqual(after.result, [], 'should not resolve after libA is removed from config');
+      assert.equal(client.hasExited, false, `server exited (code ${client.exitCode})`);
+    } finally {
+      await client.dispose();
+    }
+  });
+
   it('treats re-announcing an already-loaded library as a no-op without disturbing resolution', async function () {
     this.timeout(20_000);
 

--- a/server/src/test/runtimeLibraryLoad.test.ts
+++ b/server/src/test/runtimeLibraryLoad.test.ts
@@ -435,6 +435,54 @@ describe('runtime library loading', () => {
     }
   });
 
+  it('keeps a library available when it is also a workspace folder', async function () {
+    this.timeout(20_000);
+
+    const client = new LspTestClient();
+    try {
+      const libAUri = fileUri(LIB_A);
+      const libBUri = fileUri(LIB_B);
+      const nUri = fileUri(FILE_N);
+      const nText = fs.readFileSync(FILE_N, 'utf8');
+      const position = positionOf(nText, 'extends RuntimeLoadLibA.M', 'RuntimeLoadLibA.M');
+
+      await client.request('initialize', {
+        processId: process.pid,
+        rootUri: libBUri,
+        workspaceFolders: [
+          { uri: libAUri, name: 'RuntimeLoadLibA' },
+          { uri: libBUri, name: 'RuntimeLoadLibB' },
+        ],
+        capabilities: { workspace: { workspaceFolders: true, didChangeWorkspaceFolders: true } },
+        initializationOptions: { libraries: [LIB_A] },
+      });
+      client.notify('initialized', {});
+      client.notify('textDocument/didOpen', {
+        textDocument: { uri: nUri, languageId: 'modelica', version: 1, text: nText },
+      });
+
+      const before = await waitForDefinition(client, nUri, position, 5_000);
+      assert.ok(Array.isArray(before) && before.length > 0, 'libA should resolve initially');
+
+      client.notify('workspace/didChangeConfiguration', {
+        settings: { modelica: { libraries: [] } },
+      });
+
+      assert.ok(
+        await client.waitForLog('No loaded libraries found under removed workspace folder', 5_000),
+        'the workspace-owned library should not be unloaded',
+      );
+      const after = await waitForDefinition(client, nUri, position, 5_000);
+      assert.ok(
+        Array.isArray(after) && after.length > 0,
+        'libA should remain available through the workspace after config removal',
+      );
+      assert.equal(client.hasExited, false, `server exited (code ${client.exitCode})`);
+    } finally {
+      await client.dispose();
+    }
+  });
+
   it('treats re-announcing an already-loaded library as a no-op without disturbing resolution', async function () {
     this.timeout(20_000);
 


### PR DESCRIPTION
## Unload libraries that have been removed from the configured library set. 
This keeps the running session aligned with the current configuration.