### PR TITLE
Prepare v0.3.2 release

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelica-language-server-client",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelica-language-server-client",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "OSMC-PL-1-8",
       "dependencies": {
         "vscode-languageclient": "^10.1.0"
@@ -77,15 +77,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/chalk": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,9 +1,9 @@
 {
   "name": "modelica-language-server-client",
   "description": "VSCode part of a language server",
-  "author": "Andreas Heuermann, Osman Karabel, Evan Hedbor, PaddiM8",
+  "author": "Andreas Heuermann, Osman Karabel, Evan Hedbor, PaddiM8, John Tinnerholm",
   "license": "OSMC-PL-1-8",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "publisher": "vscode",
   "repository": {
     "type": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelica-language-server",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelica-language-server",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "hasInstallScript": true,
       "license": "OSMC-PL-1-8",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "modelica-language-server",
   "displayName": "Modelica Language Server",
   "description": "[Experimental] Modelica language server",
-  "version": "0.3.1",
-  "author": "Andreas Heuermann, Osman Karabel, Evan Hedbor, PaddiM8",
+  "version": "0.3.2",
+  "author": "Andreas Heuermann, Osman Karabel, Evan Hedbor, PaddiM8, John Tinnerholm",
   "license": "OSMC-PL-1-8",
   "repository": {
     "type": "git",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openmodelica/modelica-language-server",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openmodelica/modelica-language-server",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "(AGPL-3.0-only OR LicenseRef-OSMC-PL-1-8)",
       "dependencies": {
         "vscode-languageserver": "^10.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -7,8 +7,8 @@
     "lsp",
     "openmodelica"
   ],
-  "version": "0.3.1",
-  "author": "Andreas Heuermann, Osman Karabel, Evan Hedbor, PaddiM8",
+  "version": "0.3.2",
+  "author": "Andreas Heuermann, Osman Karabel, Evan Hedbor, PaddiM8, John Tinnerholm",
   "license": "(AGPL-3.0-only OR LicenseRef-OSMC-PL-1-8)",
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Summary

- Bump the root, client, and server packages to version 0.3.2
- Update package author lists for the 0.3.2 release
- Patched client dependency security vulnerability

The v0.3.2 release tag should be pushed after this PR is merged.