### PR TITLE
Respect MODELICA_IDE_LOG_LEVEL and stop mis-warning about restarts

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -67,6 +67,10 @@ export class ModelicaServer {
   // modelicaPath libraries are startup-only, but may overlap with a later
   // modelica.libraries update and must not be unloaded by that update.
   #modelicaPathLibraryPaths: Set<string> = new Set();
+  // Whether the client passed library roots through `initializationOptions`.
+  // Such a client drives libraries through configuration rather than workspace
+  // folders, so it does not need workspace folder change notifications.
+  #configuresLibrariesAtInitialization = false;
 
   private constructor(analyzer: Analyzer, connection: LSP.Connection) {
     this.#analyzer = analyzer;
@@ -77,10 +81,11 @@ export class ModelicaServer {
     connection: LSP.Connection,
     { workspaceFolders, initializationOptions }: LSP.InitializeParams,
   ): Promise<ModelicaServer> {
-    // Initialize logger
+    // Initialize logger. The level is deliberately not set here: forcing
+    // 'debug' sends every message to the client and leaves no way to turn the
+    // noise off, because an explicit option wins over MODELICA_IDE_LOG_LEVEL.
     setLoggerOptions({
       connection,
-      logLevel: 'debug',
     });
     logger.debug('Initializing...');
 
@@ -114,6 +119,7 @@ export class ModelicaServer {
     }
     server.#modelicaPathLibraryPaths = new Set(modelicaPath.map((value) => path.resolve(value)));
     server.#configuredLibraryPaths = new Set(configuredLibraries.map((value) => path.resolve(value)));
+    server.#configuresLibrariesAtInitialization = modelicaPath.length > 0 || configuredLibraries.length > 0;
 
     logger.debug('Initialized');
     return server;
@@ -240,10 +246,22 @@ export class ModelicaServer {
         this.onDidChangeWorkspaceFolders.bind(this),
       );
     } catch (err) {
-      logger.warn(
-        `Client does not support workspace folder change notifications; libraries added ` +
-          `after startup will require a restart. (${err instanceof Error ? err.message : err})`,
-      );
+      const reason = err instanceof Error ? err.message : err;
+      if (this.#configuresLibrariesAtInitialization) {
+        // The client already passed libraries through `initializationOptions`,
+        // so it can add more by sending `workspace/didChangeConfiguration`.
+        // Warning that a restart is needed would be wrong for such a client.
+        logger.debug(
+          `Client does not support workspace folder change notifications; libraries are ` +
+            `taken from the configuration instead. (${reason})`,
+        );
+      } else {
+        logger.warn(
+          `Client does not support workspace folder change notifications and passed no ` +
+            `libraries at initialization; libraries can only be added by sending ` +
+            `workspace/didChangeConfiguration. (${reason})`,
+        );
+      }
     }
 
     await connection.client.register(

--- a/server/src/test/runtimeLibraryLoad.test.ts
+++ b/server/src/test/runtimeLibraryLoad.test.ts
@@ -81,13 +81,26 @@ class LspTestClient {
   #exitCode: number | null | undefined = undefined;
   #logs: string[] = [];
 
-  constructor() {
+  /**
+   * @param logLevel value for MODELICA_IDE_LOG_LEVEL. Most tests assert on
+   *     `logger.debug` output, which the server only sends at 'debug'; the
+   *     server's own default is 'info'. Pass `null` to leave the variable unset
+   *     and exercise that default.
+   */
+  constructor(logLevel: string | null = 'debug') {
     assert.ok(
       fs.existsSync(SERVER_BUNDLE),
       `Server bundle not found at ${SERVER_BUNDLE}. Run 'npm run esbuild' before the tests.`,
     );
+    const env = { ...process.env };
+    if (logLevel === null) {
+      delete env.MODELICA_IDE_LOG_LEVEL;
+    } else {
+      env.MODELICA_IDE_LOG_LEVEL = logLevel;
+    }
     this.#child = spawn(process.execPath, [SERVER_BUNDLE, '--stdio'], {
       stdio: ['pipe', 'pipe', 'pipe'],
+      env,
     });
     this.#child.stdout.on('data', (chunk: Buffer) => this.#onData(chunk));
     this.#child.on('exit', (code) => {
@@ -313,6 +326,103 @@ describe('runtime library loading', () => {
       assert.ok(response.result, 'initialize should return a result');
     } finally {
       await client.dispose();
+    }
+  });
+
+  it('does not send debug messages at the default log level', async function () {
+    this.timeout(20_000);
+
+    // The server used to hardcode `logLevel: 'debug'`, which outranks
+    // MODELICA_IDE_LOG_LEVEL and left no way to quieten it. Every editor showing
+    // window/logMessage then got a debug line per hover and per definition.
+    const client = new LspTestClient(null);
+    try {
+      await client.request('initialize', {
+        processId: process.pid,
+        rootUri: null,
+        capabilities: {},
+        initializationOptions: {},
+      });
+      client.notify('initialized', {});
+      // Long enough for the debug lines of initialize/onInitialized to arrive
+      // if they were being sent at all.
+      await client.waitForLog('onInitialized', 1_000);
+      assert.deepEqual(
+        client.logs.filter((l) => l.includes(' DEBUG ')),
+        [],
+        `no DEBUG messages should be sent at the default log level; logs: ${client.logs.join(' | ')}`,
+      );
+    } finally {
+      await client.dispose();
+    }
+  });
+
+  it('sends debug messages when MODELICA_IDE_LOG_LEVEL requests them', async function () {
+    this.timeout(20_000);
+
+    const client = new LspTestClient('debug');
+    try {
+      await client.request('initialize', {
+        processId: process.pid,
+        rootUri: null,
+        capabilities: {},
+        initializationOptions: {},
+      });
+      client.notify('initialized', {});
+      assert.ok(
+        await client.waitForLog(' DEBUG ', 5_000),
+        `expected DEBUG messages with MODELICA_IDE_LOG_LEVEL=debug; logs: ${client.logs.join(' | ')}`,
+      );
+    } finally {
+      await client.dispose();
+    }
+  });
+
+  it('warns about missing workspace folder support only when no libraries were configured', async function () {
+    this.timeout(20_000);
+
+    // A client that has no workspace folder support and passed no libraries
+    // really is stuck until it sends didChangeConfiguration, so warn.
+    const bare = new LspTestClient(null);
+    try {
+      await bare.request('initialize', {
+        processId: process.pid,
+        rootUri: null,
+        capabilities: {},
+        initializationOptions: {},
+      });
+      bare.notify('initialized', {});
+      assert.ok(
+        await bare.waitForLog('passed no libraries at initialization', 5_000),
+        `expected the workspace folder warning; logs: ${bare.logs.join(' | ')}`,
+      );
+    } finally {
+      await bare.dispose();
+    }
+
+    // A client that passed libraries through initializationOptions (OMEdit uses
+    // modelicaPath) drives libraries through configuration, so telling it that
+    // libraries need a restart is wrong.
+    const configured = new LspTestClient('debug');
+    try {
+      await configured.request('initialize', {
+        processId: process.pid,
+        rootUri: null,
+        capabilities: {},
+        initializationOptions: { modelicaPath: [LIB_A] },
+      });
+      configured.notify('initialized', {});
+      assert.ok(
+        await configured.waitForLog('taken from the configuration instead', 5_000),
+        `expected the quiet variant; logs: ${configured.logs.join(' | ')}`,
+      );
+      assert.deepEqual(
+        configured.logs.filter((l) => l.includes('passed no libraries at initialization')),
+        [],
+        `a client that configured libraries should not be warned; logs: ${configured.logs.join(' | ')}`,
+      );
+    } finally {
+      await configured.dispose();
     }
   });
 


### PR DESCRIPTION
Two fixes to what the server sends clients as `window/logMessage`. Both are visible in OMEdit's Messages Browser and in the VS Code Output panel.

### 1. The log level was hardcoded, so there was no way to quieten the server

`ModelicaServer.initialize` set `logLevel: 'debug'` explicitly. Because the logger resolves the level as `_options.logLevel ?? getLogLevelFromEnvironment()`, an explicit option wins, so `MODELICA_IDE_LOG_LEVEL` could never take effect and `DEFAULT_LOG_LEVEL = 'info'` was dead code. Every client received a debug line per hover and per go-to-definition.

This has been the case since #24 (2024-05-29); it is not a regression from the recent library-loading work.

Dropping the option restores the documented behaviour: `info` by default, `MODELICA_IDE_LOG_LEVEL=debug` for the detail.

### 2. The workspace folder warning is wrong for configuration-driven clients

The warning added in #63 fires whenever a client does not advertise `workspace.workspaceFolders`:

> ⛔️ Client does not support workspace folder change notifications; libraries added after startup will require a restart.

That conclusion does not hold for a client that manages libraries through configuration. OMEdit is exactly such a client: it passes library roots as `initializationOptions.modelicaPath` and then sends `workspace/didChangeConfiguration`, so it saw this warning on every startup while loading libraries at runtime perfectly well — the message told users the opposite of what happens.

Warn only when the client also passed no libraries at initialization, and name the remedy that actually applies. A client that did pass libraries gets the same information at debug level.

### Tests

`LspTestClient` now spawns the server with `MODELICA_IDE_LOG_LEVEL=debug`, since most existing tests assert on `logger.debug` output that the server no longer sends by default. Three new tests:

- no `DEBUG` messages arrive at the default level
- `DEBUG` messages arrive with `MODELICA_IDE_LOG_LEVEL=debug`
- the warning appears for a bare client and not for one that passed `modelicaPath`, which instead gets the debug variant

Each was checked to fail when its fix is reverted. `npm run lint` clean, 42 server tests passing.

Co-Authored-By: John Tinnerholm <jtinnerholm@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkK4NDQtcR557ZsBnTrR2b