### PR TITLE
Resolve documents in libraries the client never announced

### DIFF
--- a/server/src/project/library.ts
+++ b/server/src/project/library.ts
@@ -89,6 +89,15 @@ export class ModelicaLibrary {
       library.#path = path.dirname(library.#path);
     }
 
+    if (workspaceRootDocument.within.length > 0) {
+      // The name came from the child folder we were pointed at, so it named the
+      // subpackage rather than the library: loading 'Modelica 4.1.0/Blocks'
+      // produced a library called 'Blocks' rooted at 'Modelica 4.1.0', and
+      // nothing could then resolve 'Modelica.*' against it. Derive the name
+      // from the corrected root, the same way the constructor does.
+      library.#name = path.basename(library.#path).split(/\s/)[0];
+    }
+
     logger.debug(`Set library path to ${library.path}`);
 
     const allFiles = await fs.readdir(library.#path, { recursive: true, withFileTypes: true });

--- a/server/src/project/project.ts
+++ b/server/src/project/project.ts
@@ -36,6 +36,7 @@
 import { Parser } from 'web-tree-sitter';
 import * as LSP from 'vscode-languageserver';
 import path from 'node:path';
+import * as fsSync from 'node:fs';
 
 import { ModelicaLibrary } from './library';
 import { ModelicaDocument } from './document';
@@ -188,8 +189,60 @@ export class ModelicaProject {
       return document;
     }
 
+    // The document declares a `within`, so it belongs to a library that has not
+    // been loaded. Load that library from disk rather than giving up: a client
+    // that never announced the library (or announced it only after the document
+    // was opened) would otherwise get no hover and no go-to-definition here.
+    const enclosingDocument = await this.#loadEnclosingLibrary(documentPath);
+    if (enclosingDocument !== undefined) {
+      return enclosingDocument;
+    }
+
     logger.debug(`Failed to add document '${documentPath}': not a part of any libraries.`);
     return undefined;
+  }
+
+  /**
+   * Loads the library that `documentPath` belongs to, discovering its root from
+   * the document's own directory.
+   *
+   * {@link ModelicaLibrary.load} walks up from the directory it is given to the
+   * real library root using the `within` depth of that directory's
+   * `package.mo`, so a file deep inside a library brings in the whole library.
+   *
+   * @param documentPath path to a document with a non-empty `within` clause
+   * @returns the loaded document, or `undefined` if no enclosing library could
+   *     be loaded
+   */
+  async #loadEnclosingLibrary(documentPath: string): Promise<ModelicaDocument | undefined> {
+    const directory = path.dirname(documentPath);
+    if (!fsSync.existsSync(path.join(directory, 'package.mo'))) {
+      // A loose file next to no `package.mo` is not part of a library on disk,
+      // so there is no root to discover.
+      return undefined;
+    }
+
+    let library: ModelicaLibrary;
+    try {
+      library = await ModelicaLibrary.load(this, directory, false);
+    } catch (err) {
+      logger.debug(
+        `Could not load the library enclosing '${documentPath}': ` +
+          `${err instanceof Error ? err.message : err}`,
+      );
+      return undefined;
+    }
+
+    this.addLibrary(library);
+
+    const document = library.documents.get(documentPath);
+    if (document === undefined) {
+      logger.debug(`Library '${library.name}' does not contain '${documentPath}'.`);
+      return undefined;
+    }
+
+    logger.debug(`Added document: ${documentPath}`);
+    return document;
   }
 
   /**

--- a/server/src/project/test/TestLibrary 1.0.0/Sub/Inner.mo
+++ b/server/src/project/test/TestLibrary 1.0.0/Sub/Inner.mo
@@ -1,0 +1,7 @@
+within TestLibrary.Sub;
+
+model Inner
+  Real y;
+equation
+  y = 2;
+end Inner;

--- a/server/src/project/test/TestLibrary 1.0.0/Sub/package.mo
+++ b/server/src/project/test/TestLibrary 1.0.0/Sub/package.mo
@@ -1,0 +1,4 @@
+within TestLibrary;
+
+package Sub
+end Sub;

--- a/server/src/project/test/project.test.ts
+++ b/server/src/project/test/project.test.ts
@@ -35,12 +35,15 @@
 
 import { ModelicaProject, ModelicaLibrary } from '..';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { initializeParser } from '../../parser';
 
 const TEST_LIBRARY_PATH = path.join(__dirname, 'TestLibrary 1.0.0');
 const TEST_PACKAGE_PATH = path.join(TEST_LIBRARY_PATH, 'package.mo');
 const TEST_CLASS_PATH = path.join(TEST_LIBRARY_PATH, 'HalfAdder.mo');
+const SUB_PACKAGE_PATH = path.join(TEST_LIBRARY_PATH, 'Sub');
 
 const TEST_PACKAGE_CONTENT = `package TestLibrary
   annotation(version="1.0.0");
@@ -50,6 +53,21 @@ end TestLibrary;
 describe('ModelicaProject', () => {
   describe('an empty project', () => {
     let project: ModelicaProject;
+    let orphanDirectory: string;
+    let orphanPath: string;
+
+    before(() => {
+      // A document that belongs to no library on disk: it has a within clause,
+      // so it cannot be loaded as a standalone document, and there is no
+      // `package.mo` beside it, so no library root can be discovered either.
+      orphanDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'modelica-ls-test-'));
+      orphanPath = path.join(orphanDirectory, 'Orphan.mo');
+      fs.writeFileSync(orphanPath, 'within TestLibrary;\n\nmodel Orphan\nend Orphan;\n', 'utf-8');
+    });
+
+    after(() => {
+      fs.rmSync(orphanDirectory, { recursive: true, force: true });
+    });
 
     beforeEach(async () => {
       const parser = await initializeParser();
@@ -60,9 +78,48 @@ describe('ModelicaProject', () => {
       assert.equal(project.libraries.length, 0);
     });
 
-    it('updating and deleting documents does nothing', async () => {
-      assert(!await project.updateDocument(TEST_CLASS_PATH, 'file content'));
-      assert(!await project.removeDocument(TEST_CLASS_PATH));
+    it('updating and deleting documents outside any library does nothing', async () => {
+      // This used to be asserted with a document from TestLibrary. Such a
+      // document is now discovered and loaded on demand, so the claim only
+      // holds for a document no library on disk contains.
+      assert(!await project.updateDocument(orphanPath, 'file content'));
+      assert(!await project.removeDocument(orphanPath));
+    });
+
+    it('adds a document by discovering the library its within clause names', async () => {
+      // HalfAdder.mo declares `within TestLibrary;` and no library is loaded,
+      // so it can only be added by finding the library root on disk. A client
+      // that opens a file before (or without) announcing its library depends
+      // on this; otherwise the document is never loaded and nothing in it
+      // resolves.
+      const document = await project.addDocument(TEST_CLASS_PATH);
+      assert.ok(document, 'expected the document to be added');
+      assert.equal(project.libraries.length, 1);
+      assert.equal(project.libraries[0].name, 'TestLibrary');
+      // The whole library is loaded, not just the document that was opened.
+      assert.notEqual(await project.getDocument(TEST_PACKAGE_PATH), undefined);
+    });
+
+    it('updating a document discovers its library too', async () => {
+      assert(await project.updateDocument(TEST_CLASS_PATH, 'within TestLibrary;\n'));
+      assert.equal(project.libraries.length, 1);
+    });
+
+    it('does not add a document that no library on disk contains', async () => {
+      assert.equal(await project.addDocument(orphanPath), undefined);
+      assert.equal(project.libraries.length, 0);
+    });
+
+    it('names a library after its root, not the subfolder it was found from', async () => {
+      // ModelicaLibrary.load walks up to the real root when pointed at a child
+      // folder, but used to keep the child's name: loading
+      // 'TestLibrary 1.0.0/Sub' gave a library called 'Sub' rooted at
+      // 'TestLibrary 1.0.0', so nothing could resolve 'TestLibrary.*' against
+      // it. Discovering a library from a document inside a subpackage makes
+      // this the common case.
+      const library = await ModelicaLibrary.load(project, SUB_PACKAGE_PATH, false);
+      assert.equal(library.name, 'TestLibrary');
+      assert.equal(library.path, TEST_LIBRARY_PATH);
     });
   });
 

--- a/server/src/test/runtimeLibraryLoad.test.ts
+++ b/server/src/test/runtimeLibraryLoad.test.ts
@@ -58,6 +58,7 @@ const LIB_A = path.join(__dirname, 'fixtures', 'RuntimeLoadLibA');
 const LIB_B = path.join(__dirname, 'fixtures', 'RuntimeLoadLibB');
 const LIB_C = path.join(__dirname, 'fixtures', 'RuntimeLoadLibC');
 const FILE_N = path.join(LIB_B, 'N.mo');
+const FILE_M = path.join(LIB_A, 'M.mo');
 const FILE_P = path.join(LIB_C, 'P.mo');
 
 function fileUri(p: string): string {
@@ -241,6 +242,52 @@ async function initializeWithLibB(client: LspTestClient): Promise<void> {
 }
 
 describe('runtime library loading', () => {
+  it('resolves inside a document whose library was never announced', async function () {
+    this.timeout(20_000);
+
+    // What AnHeuermann hit in OpenModelica#15925: opening a file that belongs
+    // to a library the client never announced. The document declares a within
+    // clause, so it could not be loaded as a standalone document, and the
+    // server gave up with "not a part of any libraries" - nothing in the file
+    // resolved, not even a local declaration.
+    const client = new LspTestClient();
+    try {
+      const mUri = fileUri(FILE_M);
+      const mText = fs.readFileSync(FILE_M, 'utf8');
+      const lines = mText.split('\n');
+      const lineIndex = lines.findIndex((l) => l.includes('x = 1'));
+      assert.notEqual(lineIndex, -1, 'fixture file must contain the equation');
+      const position = { line: lineIndex, character: lines[lineIndex].indexOf('x') };
+
+      // No workspace folders and no configured libraries: the server knows
+      // nothing about RuntimeLoadLibA.
+      await client.request('initialize', {
+        processId: process.pid,
+        rootUri: null,
+        capabilities: {},
+        initializationOptions: {},
+      });
+      client.notify('initialized', {});
+      client.notify('textDocument/didOpen', {
+        textDocument: { uri: mUri, languageId: 'modelica', version: 1, text: mText },
+      });
+
+      const result = await waitForDefinition(client, mUri, position, 5_000);
+      assert.ok(
+        Array.isArray(result) && result.length > 0,
+        `expected 'x' to resolve once the enclosing library is discovered, got: ${JSON.stringify(result)}`,
+      );
+      const target = result[0] as { uri?: string; targetUri?: string };
+      assert.equal(
+        target.uri ?? target.targetUri,
+        mUri,
+        `expected the declaration in M.mo, got: ${JSON.stringify(result[0])}`,
+      );
+    } finally {
+      await client.dispose();
+    }
+  });
+
   it('resolves an external reference only after the library is announced without a restart', async function () {
     this.timeout(20_000);
 

--- a/server/src/util/logger.ts
+++ b/server/src/util/logger.ts
@@ -96,8 +96,10 @@ export class Logger {
   }
 
   static MESSAGE_TYPE_TO_LOG_LEVEL_MSG: Record<LSP.MessageType, string> = {
-    [LSP.MessageType.Error]: 'ERROR ⛔️',
-    [LSP.MessageType.Warning]: 'WARNING ⛔️',
+    // Plain ASCII: OMEdit's Messages Browser renders these with a font that has
+    // no colour-emoji glyph, so an emoji here shows up as a replacement box.
+    [LSP.MessageType.Error]: 'ERROR',
+    [LSP.MessageType.Warning]: 'WARNING',
     [LSP.MessageType.Info]: 'INFO',
     [LSP.MessageType.Log]: 'LOG',
     [LSP.MessageType.Debug]: 'DEBUG',

--- a/server/src/util/test/logger.test.ts
+++ b/server/src/util/test/logger.test.ts
@@ -1,0 +1,50 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+
+import assert from 'node:assert/strict';
+
+import { Logger } from '../logger';
+
+describe('Logger', () => {
+  it('labels levels in plain ASCII', () => {
+    // The labels are sent to clients as `window/logMessage` text. OMEdit's
+    // Messages Browser renders them with a font that has no colour-emoji
+    // glyph, so an emoji here reaches the user as a replacement box.
+    for (const label of Object.values(Logger.MESSAGE_TYPE_TO_LOG_LEVEL_MSG)) {
+      assert.match(label, /^[\x20-\x7e]*$/, `log level label ${JSON.stringify(label)} must be ASCII`);
+    }
+  });
+});


### PR DESCRIPTION
Two changes for OpenModelica#15925, aimed at a v0.3.3 that OMEdit can pin.

Closes #77.

### 1. A document in an unannounced library was unusable

Opening a file that belongs to a library the server has not been told about gave no hover and no go-to-definition — not even for a declaration in the same file.

`Project.addDocument` can load a document with no `within` clause as a standalone library, but a document inside a package has one, so it fell through to:

```
Failed to add document '...': not a part of any libraries.
```

This is exactly what @AnHeuermann reported: `spring` in `Modelica.Blocks.Examples.PID_Controller` would not resolve until the MSL was added by hand under *Library Paths*. A client can avoid it by announcing libraries first (OMEdit now does), but the server shouldn't depend on the client getting that right.

Now the enclosing library is loaded instead. `ModelicaLibrary.load` already finds the real root by walking up from the directory it is given, using the `within` depth of that directory's `package.mo`, so pointing it at the document's own directory is enough. When there is no `package.mo` beside the document there is nothing to discover and the old behaviour stands.

**A latent bug this exposed (#77):** that walk-up kept the name the library was constructed with — the folder it started from, not the root. Loading `Modelica 4.1.0/Blocks` produced a library named `Blocks` rooted at `Modelica 4.1.0`, so nothing could resolve `Modelica.*` against it. Harmless while libraries were only ever loaded from their root; the common case now. The name is derived from the corrected root.

### 2. No emoji in log labels

`ERROR ⛔️` / `WARNING ⛔️` are sent to clients as `window/logMessage` text. OMEdit's Messages Browser renders them with a font that has no colour-emoji glyph, so users see a replacement box — @AnHeuermann asked for these to go. (It looks like a missing glyph rather than a UTF-8 problem in the messages tab; the surrounding text renders fine.)

### Verification

Against the real `Modelica 4.1.0+maint.om` on disk, with nothing announced to the server:

```
symbol at 56:10 -> der(spring.w_rel) = 0;
RESULT: RESOLVED -> .../Modelica 4.1.0+maint.om/Blocks/package.mo:34
   library Modelica @ .../Modelica 4.1.0+maint.om (2552 docs)  [~4 s]
```

The same call on `main` reports `RESULT: NOT RESOLVED`.

Five new tests (project-level discovery, the no-library case, the library naming, an end-to-end LSP definition request in an unannounced library, and ASCII log labels). Each was checked to fail with its fix reverted. `npm run lint` clean, 45 server tests passing.

### Behaviour changes

Both are deliberate, not side effects:

- **Opening one file inside a large library loads the whole library** (~4 s and 2552 documents for the MSL). This is the cost of the fix: resolution needs the library, and it is the same work the client's own sync does, once per library.
- **A `didChange` for a file inside a library on disk loads that library** rather than failing, because `updateDocument` resolves through the same path. Loading a document that is being edited is the correct behaviour — the alternative is to keep failing every edit to a file whose library was never announced, which is the bug this PR is fixing. Consequently the test asserting an empty project cannot update a document has been narrowed to a document that no library on disk contains, which is where the claim still holds.

Co-Authored-By: John Tinnerholm <jtinnerholm@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkK4NDQtcR557ZsBnTrR2b

