### PR TITLE
Updates for release 3.3

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelica-language-server-client",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelica-language-server-client",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "OSMC-PL-1-8",
       "dependencies": {
         "vscode-languageclient": "^10.1.1"

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "description": "VSCode part of a language server",
   "author": "Andreas Heuermann, Osman Karabel, Evan Hedbor, PaddiM8, John Tinnerholm",
   "license": "OSMC-PL-1-8",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "publisher": "vscode",
   "repository": {
     "type": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelica-language-server",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelica-language-server",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "hasInstallScript": true,
       "license": "OSMC-PL-1-8",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "modelica-language-server",
   "displayName": "Modelica Language Server",
   "description": "[Experimental] Modelica language server",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "author": "Andreas Heuermann, Osman Karabel, Evan Hedbor, PaddiM8, John Tinnerholm",
   "license": "OSMC-PL-1-8",
   "repository": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openmodelica/modelica-language-server",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openmodelica/modelica-language-server",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "(AGPL-3.0-only OR LicenseRef-OSMC-PL-1-8)",
       "dependencies": {
         "vscode-languageserver": "^10.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
     "lsp",
     "openmodelica"
   ],
-  "version": "0.3.2",
+  "version": "0.3.3",
   "author": "Andreas Heuermann, Osman Karabel, Evan Hedbor, PaddiM8, John Tinnerholm",
   "license": "(AGPL-3.0-only OR LicenseRef-OSMC-PL-1-8)",
   "engines": {


### PR DESCRIPTION
Version bump to 0.3.3 in the three `package.json` files and their lockfiles, the same shape as #73 was for 0.3.2.

Needs to land before the `v0.3.3` tag is pushed: the release job builds the vsix and the npm tarball from these versions, and publishing 0.3.2 artifacts a second time would be rejected by both npm and the Marketplace.

Contents of the release, on top of v0.3.2:

- #75 — documents in libraries the client never announced now resolve, and log labels are plain ASCII (closes #77)
- #68, #76 — dependency and workflow bumps

Commit authored by @JKRT; pushed from the fork because the agent account has read-only access here.